### PR TITLE
Add setting to define JETPACK_BETA_BLOCKS on the Jetpack Constant page.

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -153,6 +153,13 @@ function companion_add_jetpack_constants_option_page() {
 							),
 							'placeholder' => esc_attr( $jetpack_sandbox_domain ),
 						),
+						'jetpack_beta_blocks' => array(
+							'id' => 'jetpack_beta_blocks',
+							'title' => __( 'JETPACK_BETA_BLOCKS', 'companion' ),
+							'text' =>
+								esc_html__( 'Check to enable Jetpack blocks for Gutenberg that are on Beta stage of development', 'companion' ),
+							'type' => 'checkbox',
+						),
 						'jetpack_protect_api_host' => array(
 							'id' => 'jetpack_protect_api_host',
 							'title' => __( 'JETPACK_PROTECT__API_HOST', 'companion' ),
@@ -214,6 +221,6 @@ function companion_tamper_with_jetpack_constants() {
 		define( 'JETPACK_PROTECT__API_HOST', companion_get_option( 'jetpack_protect_api_host', '' ) );
 	}
 	if ( companion_get_option( 'jetpack_beta_blocks', '' ) ) {
-		define( 'JETPACK_BETA_BLOCKS', companion_get_option( 'jetpack_beta_blocks', '' ) );
+		define( 'JETPACK_BETA_BLOCKS', companion_get_option( 'jetpack_beta_blocks', '' ) ? true : false );
 	}
 }

--- a/companion.php
+++ b/companion.php
@@ -30,7 +30,7 @@ function companion_admin_notices() {
 	$sysuser_option_key = 'jurassic_ninja_sysuser';
 	$admin_password = is_multisite() ? get_blog_option( 1, $password_option_key ) : get_option( $password_option_key );
 	$sysuser = is_multisite() ? get_blog_option( 1, $sysuser_option_key ) : get_option( $sysuser_option_key );
-	$host = parse_url( network_site_url(), PHP_URL_HOST ); 
+	$host = parse_url( network_site_url(), PHP_URL_HOST );
 	?>
 	<div class="notice notice-success is-dismissible">
 		<h3><?php echo esc_html__( 'Welcome to Jurassic Ninja!' ); ?></h3>
@@ -46,7 +46,7 @@ function companion_admin_notices() {
 	</div>
 	<style type="text/css">
 		#jurassic_ssh_command {
-			user-select: all;	
+			user-select: all;
 		}
 	</style>
 	<?php
@@ -212,5 +212,8 @@ function companion_tamper_with_jetpack_constants() {
 	}
 	if ( companion_get_option( 'jetpack_protect_api_host', '' ) ) {
 		define( 'JETPACK_PROTECT__API_HOST', companion_get_option( 'jetpack_protect_api_host', '' ) );
+	}
+	if ( companion_get_option( 'jetpack_beta_blocks', '' ) ) {
+		define( 'JETPACK_BETA_BLOCKS', companion_get_option( 'jetpack_beta_blocks', '' ) );
 	}
 }

--- a/companion.php
+++ b/companion.php
@@ -3,7 +3,7 @@
 Plugin Name: Companion Plugin
 Plugin URI: https://github.com/Automattic/companion
 Description: Helps keep the launched WordPress in order.
-Version: 1.4
+Version: 1.5
 Author: Osk
 */
 


### PR DESCRIPTION
Adds ability to use a checkbox for defining the JETPACK_BETA_BLOCKS constant that enables the Jetpack blocks for Gutenberg that are still being developed and on Beta stage.

![image](https://user-images.githubusercontent.com/746152/48431733-01d94080-e738-11e8-86da-f3b0ea7a58da.png)
