### PR TITLE
Work around rogue Jetpack beta version check

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -173,7 +173,7 @@ function companion_site_uses_https() {
 
 function companion_add_jetpack_constants_option_page() {
 	$jetpack_beta_present_and_supports_jetpack_constants_settings = class_exists( 'Jetpack_Beta' ) &&
-		version_compare( JPBETA_VERSION, '2', '>' );
+		version_compare( JPBETA_VERSION, '3', '>' );
 	if ( ! companion_is_jetpack_here() || $jetpack_beta_present_and_supports_jetpack_constants_settings ) {
 		return;
 	}

--- a/companion.php
+++ b/companion.php
@@ -3,7 +3,7 @@
 Plugin Name: Companion Plugin
 Plugin URI: https://github.com/Automattic/companion
 Description: Helps keep the launched WordPress in order.
-Version: 1.9
+Version: 1.10
 Author: Osk
 */
 


### PR DESCRIPTION
We're checking for Jetpack Beta 2.something and deciding not to show Jetpack Constants, but it doesn't support the constants page yet