### PR TITLE
Do nothing if the constant IS_ATOMIC is defined and truthy

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -7,6 +7,14 @@ Version: 1.10
 Author: Osk
 */
 
+// Do nothing if it happens to be running in an Atomic site.
+// This may happen when importing a full Jurassic Ninja site into an Atomic one
+// and this plugin is eventually imported into the site.
+if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+	return true;
+}
+
+// Do a minimal set of stuff on a multisite installation on sites other than the main one
 if ( is_multisite() && ! is_main_site() ) {
 	add_action( 'pre_current_active_plugins', 'companion_hide_plugin' );
 	add_action( 'admin_notices', 'companion_admin_notices' );

--- a/companion.php
+++ b/companion.php
@@ -3,7 +3,7 @@
 Plugin Name: Companion Plugin
 Plugin URI: https://github.com/Automattic/companion
 Description: Helps keep the launched WordPress in order.
-Version: 1.10
+Version: 1.11
 Author: Osk
 */
 


### PR DESCRIPTION
Makes the plugin do nothing if it happens to be running in an .comm site. This may happen when importing a full Jurassic Ninja site into an .com one. This plugin is eventually imported into the site.