### PR TITLE
Call array_values on the call_user_func_array $params argument.

### DIFF
--- a/RationalOptionPages.php
+++ b/RationalOptionPages.php
@@ -280,7 +280,7 @@ class RationalOptionPages {
 								$params['callback'] = array( $this, $params['callback'] );
 							}
 					
-							add_settings_field( ...array_values( params ) );
+							add_settings_field( ...array_values( $params ) );
 						}
 					}
 				}

--- a/RationalOptionPages.php
+++ b/RationalOptionPages.php
@@ -253,7 +253,7 @@ class RationalOptionPages {
 						$params['callback'] = array( $this, $params['callback'] );
 					}
 			
-					call_user_func_array( 'add_settings_section', $params );
+					call_user_func_array( 'add_settings_section', array_values( $params ) );
 					
 					if ( !empty( $section_params['fields'] ) ) {
 						foreach ( $section_params['fields'] as $field_key => $field_params ) {
@@ -280,7 +280,7 @@ class RationalOptionPages {
 								$params['callback'] = array( $this, $params['callback'] );
 							}
 					
-							call_user_func_array( 'add_settings_field', $params );
+							call_user_func_array( 'add_settings_field', array_values( params ) );
 						}
 					}
 				}
@@ -303,7 +303,7 @@ class RationalOptionPages {
 			// Finalize callback
 			$params['callback'] = array( $this, $params['callback'] );
 			
-			call_user_func_array( $page['function'], $params );
+			call_user_func_array( $page['function'], array_values( $params ) );
 		}
 	}
 	

--- a/RationalOptionPages.php
+++ b/RationalOptionPages.php
@@ -280,7 +280,7 @@ class RationalOptionPages {
 								$params['callback'] = array( $this, $params['callback'] );
 							}
 					
-							call_user_func_array( 'add_settings_field', array_values( params ) );
+							add_settings_field( ...array_values( params ) );
 						}
 					}
 				}

--- a/RationalOptionPages.php
+++ b/RationalOptionPages.php
@@ -253,7 +253,7 @@ class RationalOptionPages {
 						$params['callback'] = array( $this, $params['callback'] );
 					}
 			
-					call_user_func_array( 'add_settings_section', array_values( $params ) );
+					add_settings_section( ...array_values( $params ) );
 					
 					if ( !empty( $section_params['fields'] ) ) {
 						foreach ( $section_params['fields'] as $field_key => $field_params ) {


### PR DESCRIPTION
Reported on slack: p1613095656009500-slack-CA17PSW87

This fatal occurs when creating a new JN site with PHP 8.0:

Fatal error: Uncaught Error: Unknown named parameter $callback in .../wp-content/plugins/companion/RationalOptionPages.php:306
Stack trace: #0 .../wp-includes/class-wp-hook.php(287): RationalOptionPages->admin_menu('')
1 .../wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters(NULL, Array)
2 .../wp-includes/plugin.php(484): WP_Hook->do_action(Array)
3 .../wp-admin/includes/menu.php(155): do_action('admin_menu', '')
4 .../wp-admin/menu.php(327): require_once('/srv/users/user...')
5 .../wp-admin/admin.php(158): require('/srv/users/user...')
6 .../wp-admin/index.php(10): require_once('/srv/users/user...')
7 {main} thrown in .../wp-content/plugins/companion/RationalOptionPages.php on line 306


The `$params` argument that's passed to `call_user_func_array` in line 306 is an associative array:
     
     call_user_func_array( $page['function'], $params );

In PHP 8, the array keys of the `$params` argument are used as parameter names , which I believe causes the error: https://php.watch/versions/8.0/named-parameters#named-params-call_user_func_array

I think this can be fixed by by calling `array_values()` on `$parms` in the three `call_user_func_array` calls.