### PR TITLE
Fix the way JETPACK_PROTECT__API_HOST is handled in Jetpack constants

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -247,6 +247,7 @@ function companion_add_jetpack_constants_option_page() {
 	);
 
 	$jetpack_sandbox_domain = defined( 'JETPACK__SANDBOX_DOMAIN' ) ? JETPACK__SANDBOX_DOMAIN : '';
+	$jetpack_protect_api_host = defined( 'JETPACK_PROTECT__API_HOST' ) ? JETPACK_PROTECT__API_HOST : '';
 
 	$global_fields = array(
 		'jetpack_sandbox_domain' => array(
@@ -275,9 +276,9 @@ function companion_add_jetpack_constants_option_page() {
 				'title' => __( 'JETPACK_PROTECT__API_HOST', 'companion' ),
 				'text' => sprintf(
 					esc_html__( "Base URL for API requests to Jetpack Protect's REST API. Current value for JETPACK_PROTECT__API_HOST: %s", 'companion' ),
-					'<code>' . esc_html( JETPACK_PROTECT__API_HOST ) . '</code>'
+					'<code>' . esc_html( $jetpack_protect_api_host ) . '</code>'
 				),
-				'placeholder' => esc_attr( JETPACK_PROTECT__API_HOST ),
+				'placeholder' => esc_attr( $jetpack_protect_api_host ),
 			),
 			'jetpack_should_not_use_connection_iframe' => array(
 				'id' => 'jetpack_should_not_use_connection_iframe',

--- a/companion.php
+++ b/companion.php
@@ -3,7 +3,7 @@
 Plugin Name: Companion Plugin
 Plugin URI: https://github.com/Automattic/companion
 Description: Helps keep the launched WordPress in order.
-Version: 1.19
+Version: 1.20
 Author: Osk
 */
 


### PR DESCRIPTION
Fixes error:

```
Warning: Use of undefined constant JETPACK_PROTECT__API_HOST - assumed 'JETPACK_PROTECT__API_HOST' (this will throw an Error in a future version of PHP) in /srv/users/userc985b09d/apps/userc985b09d/public/wp-content/plugins/companion/companion.php on line 278
```