### PR TITLE
Add/jetpack protect constants

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -321,6 +321,50 @@ function companion_add_jetpack_constants_option_page() {
 		);
 	}
 
+	/**
+	 * Jetpack Protect options
+	 */
+	if ( class_exists( 'Jetpack_Protect' ) ) {
+		$options_page['companion']['sections']['jetpack_protect'] = array(
+			'title' => __( 'Jetpack Protect', 'companion' ),
+			'text'  => '<p>' . __( 'Configure some defaults constants used by Jetpack Protect development plugin', 'companion' ) . '</p>',
+			'fields' => array(
+				'jetpack_protect_bypass_cache' => array(
+					'id' => 'jetpack_protect_bypass_cache',
+					'title' => __( 'Bypass cache', 'companion' ),
+					'text' =>
+						esc_html__( 'Check to bypass local cache and always ask WPCOM for fresh information on vulnerabilities', 'companion' ),
+					'type' => 'checkbox',
+				),
+				'jetpack_protect_response_type' => array(
+					'id' => 'jetpack_protect_response_type',
+					'title' => __( 'Response type', 'companion' ),
+					'text' => sprintf(
+						esc_html__( "What response would you like to get from WPCOM?", 'companion' )
+					),
+					'type' => 'select',
+					'choices' => array(
+						'empty' => 'Empty: Response as if the first check was not performed yet',
+						'complete_green' => 'Complete Green: Response will include all plugins and zero vulnerabitlies',
+						'incomplete_green' => 'Incomplete Green: Response will miss one plugin and have zero vulnerabilities',
+						'complete' => 'Complete: Response will include all plugins and 2 of them will have vulnerabilities',
+						'incomplete' => 'Incomplete: Response will miss one plugin and 2 of them will have vulnerabilities',
+					),
+				),
+				'jetpack_protect_core_vuls' => array(
+					'id' => 'jetpack_protect_core_vuls',
+					'title' => __( 'Number of core vulnerabilities', 'companion' ),
+					'text' =>
+						esc_html__( 'The number of vulnerabilities found in WP core that the response should include.', 'companion' ),
+					'type' => 'number',
+				),
+			),
+		);
+	}
+	/**
+	 * End of Jetpack Protect options
+	 */
+
 	$options_page['companion']['sections']['jetpack_tweaks']['fields'] = array_merge( $global_fields, $jetpack_fields );
 
 	new RationalOptionPages( $options_page );
@@ -360,4 +404,20 @@ function companion_tamper_with_jetpack_constants() {
 	if ( ! ( defined( 'JETPACK_BOOST_CLOUD_CSS' ) && JETPACK_BOOST_CLOUD_CSS ) && companion_get_option( 'jetpack_boost_cloud_css', '' ) ) {
 		define( 'JETPACK_BOOST_CLOUD_CSS', companion_get_option( 'jetpack_boost_cloud_css', '' ) ? true : false );
 	}
+
+	/**
+	 * Jetpack Protect options
+	 */
+	if ( ! ( defined( 'JETPACK_PROTECT_DEV__BYPASS_CACHE' ) && JETPACK_PROTECT_DEV__BYPASS_CACHE ) && companion_get_option( 'jetpack_protect_bypass_cache', '' ) ) {
+		define( 'JETPACK_PROTECT_DEV__BYPASS_CACHE', companion_get_option( 'jetpack_protect_bypass_cache', '' ) ? true : false );
+	}
+	if ( ! ( defined( 'JETPACK_PROTECT_DEV__API_RESPONSE_TYPE' ) && JETPACK_PROTECT_DEV__API_RESPONSE_TYPE ) && companion_get_option( 'jetpack_protect_response_type', '' ) ) {
+		define( 'JETPACK_PROTECT_DEV__API_RESPONSE_TYPE', companion_get_option( 'jetpack_protect_response_type', '' ) );
+	}
+	if ( ! ( defined( 'JETPACK_PROTECT_DEV__API_CORE_VULS' ) && JETPACK_PROTECT_DEV__API_CORE_VULS ) && companion_get_option( 'jetpack_protect_core_vuls', '' ) ) {
+		define( 'JETPACK_PROTECT_DEV__API_CORE_VULS', companion_get_option( 'jetpack_protect_core_vuls', '' ) );
+	}
+	/**
+	 * End of Jetpack Protect options
+	 */
 }

--- a/companion.php
+++ b/companion.php
@@ -298,7 +298,7 @@ function companion_add_jetpack_constants_option_page() {
 				'id' => 'jetpack_protect_api_host',
 				'title' => __( 'JETPACK_PROTECT__API_HOST', 'companion' ),
 				'text' => sprintf(
-					esc_html__( "Base URL for API requests to Jetpack Protect's REST API. Current value for JETPACK_PROTECT__API_HOST: %s", 'companion' ),
+					esc_html__( "Base URL for API requests to Jetpack Brute force Protection REST API. Current value for JETPACK_PROTECT__API_HOST: %s", 'companion' ),
 					'<code>' . esc_html( $jetpack_protect_api_host ) . '</code>'
 				),
 				'placeholder' => esc_attr( $jetpack_protect_api_host ),

--- a/companion.php
+++ b/companion.php
@@ -262,13 +262,6 @@ function companion_add_jetpack_constants_option_page() {
 			),
 			'placeholder' => esc_attr( $jetpack_sandbox_domain ),
 		),
-		'jetpack_enable_my_jetpack' => array(
-			'id' => 'jetpack_enable_my_jetpack',
-			'title' => 'JETPACK_ENABLE_MY_JETPACK',
-			'text' =>
-				esc_html__( 'Check to enable JETPACK_ENABLE_MY_JETPACK feature flag. This will enable the My Jetpack page Work in progress.', 'companion' ),
-			'type' => 'checkbox',
-		),
 		'jetpack_boost_cloud_css' => array(
 			'id' => 'jetpack_boost_cloud_css',
 			'title' => __( 'JETPACK_BOOST_CLOUD_CSS', 'companion' ),

--- a/companion.php
+++ b/companion.php
@@ -3,7 +3,7 @@
 Plugin Name: Companion Plugin
 Plugin URI: https://github.com/Automattic/companion
 Description: Helps keep the launched WordPress in order.
-Version: 1.24
+Version: 1.25
 Author: Osk
 */
 


### PR DESCRIPTION
Adds a section to handle Jetpack Protect's options needed to run Jetpack Protect while the WPCOM endpoint is still under development

![Captura de tela de 2022-05-03 14-04-33](https://user-images.githubusercontent.com/971483/166503488-e1a631cb-ef73-494a-b2aa-da621b314599.png)
