### PR TITLE
Remove outdated note on mapped domains for sandboxes

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -257,7 +257,7 @@ function companion_add_jetpack_constants_option_page() {
 			'id' => 'jetpack_sandbox_domain',
 			'title' => __( 'JETPACK__SANDBOX_DOMAIN', 'companion' ),
 			'text' => sprintf(
-				esc_html__( "The domain of a WordPress.com Sandbox to which you wish to send all of Jetpack's remote requests. Must be a ___.wordpress.com subdomain with DNS permanently pointed to a WordPress.com sandbox. Current value for JETPACK__SANDBOX_DOMAIN: %s", 'companion' ),
+				esc_html__( "The domain of a WordPress.com Sandbox to which you wish to send all of Jetpack's remote requests. Current value for JETPACK__SANDBOX_DOMAIN: %s", 'companion' ),
 				'<code>' . esc_html( $jetpack_sandbox_domain ) . '</code>'
 			),
 			'placeholder' => esc_attr( $jetpack_sandbox_domain ),

--- a/companion.php
+++ b/companion.php
@@ -3,7 +3,7 @@
 Plugin Name: Companion Plugin
 Plugin URI: https://github.com/Automattic/companion
 Description: Helps keep the launched WordPress in order.
-Version: 1.25
+Version: 1.26
 Author: Osk
 */
 


### PR DESCRIPTION
Removes outdated clarification on the mapping requirement for sandbox domains