### PR TITLE
Add day countdown to companion

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -411,7 +411,34 @@ function companion_tamper_with_jetpack_constants() {
 	if ( ! ( defined( 'JETPACK_PROTECT_DEV__API_CORE_VULS' ) && JETPACK_PROTECT_DEV__API_CORE_VULS ) && companion_get_option( 'jetpack_protect_core_vuls', '' ) ) {
 		define( 'JETPACK_PROTECT_DEV__API_CORE_VULS', companion_get_option( 'jetpack_protect_core_vuls', '' ) );
 	}
-	/**
-	 * End of Jetpack Protect options
-	 */
+}
+
+/**
+ * Make an API request to the main Jurassic Ninja server.
+ *
+ * @param string $endpoint The endpoint to request. Valid values are 'extend' and 'checkin'.
+ *
+ * @return void
+ * @throws Exception When an invalid endpoint is provided.
+ */
+function companion_api_request( string $endpoint ) {
+	$endpoint = trim( $endpoint, ' /' );
+	$valid_endpoints = [
+		'extend' => true,
+		'checkin' => true,
+	];
+
+	if ( ! isset( $valid_endpoints[ $endpoint ] ) ) {
+		throw new Exception( sprintf( 'Invalid endpoint: %s', $endpoint ) );
+	}
+
+	$api_base_url = companion_get_api_base_url();
+	$domain       = parse_url( network_site_url(), PHP_URL_HOST );
+	wp_remote_post(
+		"{$api_base_url}/{$endpoint}",
+		[
+			'headers' => [ 'content-type' => 'application/json' ],
+			'body'    => json_encode( [ 'domain' => $domain ] ),
+		]
+	);
 }

--- a/companion.php
+++ b/companion.php
@@ -1,10 +1,10 @@
 <?php
-/*
-Plugin Name: Companion Plugin
-Plugin URI: https://github.com/Automattic/companion
-Description: Helps keep the launched WordPress in order.
-Version: 1.28
-Author: Osk
+/**
+ * Plugin Name: Companion Plugin
+ * Plugin URI: https://github.com/Automattic/companion
+ * Description: Helps keep the launched WordPress in order.
+ * Version: 1.28
+ * Author: Osk
 */
 
 // Do nothing if it happens to be running in an Atomic site.
@@ -383,27 +383,25 @@ function companion_tamper_with_jetpack_constants() {
 		define( 'JETPACK_PROTECT__API_HOST', companion_get_option( 'jetpack_protect_api_host', '' ) );
 	}
 	if ( ! ( defined( 'JETPACK_BETA_BLOCKS' ) && JETPACK_BETA_BLOCKS ) && companion_get_option( 'jetpack_beta_blocks', '' ) ) {
-		define( 'JETPACK_BETA_BLOCKS', companion_get_option( 'jetpack_beta_blocks', '' ) ? true : false );
+		define( 'JETPACK_BETA_BLOCKS', (bool) companion_get_option( 'jetpack_beta_blocks', '' ) );
 	}
 	if ( ! ( defined( 'JETPACK_EXPERIMENTAL_BLOCKS' ) && JETPACK_EXPERIMENTAL_BLOCKS ) && companion_get_option( 'jetpack_experimental_blocks', '' ) ) {
-		define( 'JETPACK_EXPERIMENTAL_BLOCKS', companion_get_option( 'jetpack_experimental_blocks', '' ) ? true : false );
+		define( 'JETPACK_EXPERIMENTAL_BLOCKS', (bool) companion_get_option( 'jetpack_experimental_blocks', '' ) );
 	}
 	if ( ! ( defined( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME' ) && JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME ) && companion_get_option( 'jetpack_should_not_use_connection_iframe', '' ) ) {
-		define( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME', companion_get_option( 'jetpack_should_not_use_connection_iframe', '' ) ? true : false );
+		define( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME', (bool) companion_get_option( 'jetpack_should_not_use_connection_iframe', '' ) );
 	}
 	if ( ! ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) && companion_get_option( 'jetpack_dev_debug', '' ) ) {
-		define( 'JETPACK_DEV_DEBUG', companion_get_option( 'jetpack_dev_debug', '' ) ? true : false );
+		define( 'JETPACK_DEV_DEBUG', (bool) companion_get_option( 'jetpack_dev_debug', '' ) );
 	}
 
 	if ( ! ( defined( 'JETPACK_ENABLE_MY_JETPACK' ) && JETPACK_ENABLE_MY_JETPACK ) && companion_get_option( 'jetpack_enable_my_jetpack', '' ) ) {
-		define( 'JETPACK_ENABLE_MY_JETPACK', companion_get_option( 'jetpack_enable_my_jetpack', '' ) ? true : false );
+		define( 'JETPACK_ENABLE_MY_JETPACK', (bool) companion_get_option( 'jetpack_enable_my_jetpack', '' ) );
 	}
 
-	/**
-	 * Jetpack Protect options
-	 */
+	// Jetpack Protect options
 	if ( ! ( defined( 'JETPACK_PROTECT_DEV__BYPASS_CACHE' ) && JETPACK_PROTECT_DEV__BYPASS_CACHE ) && companion_get_option( 'jetpack_protect_bypass_cache', '' ) ) {
-		define( 'JETPACK_PROTECT_DEV__BYPASS_CACHE', companion_get_option( 'jetpack_protect_bypass_cache', '' ) ? true : false );
+		define( 'JETPACK_PROTECT_DEV__BYPASS_CACHE', (bool) companion_get_option( 'jetpack_protect_bypass_cache', '' ) );
 	}
 	if ( ! ( defined( 'JETPACK_PROTECT_DEV__API_RESPONSE_TYPE' ) && JETPACK_PROTECT_DEV__API_RESPONSE_TYPE ) && companion_get_option( 'jetpack_protect_response_type', '' ) ) {
 		define( 'JETPACK_PROTECT_DEV__API_RESPONSE_TYPE', companion_get_option( 'jetpack_protect_response_type', '' ) );

--- a/companion.php
+++ b/companion.php
@@ -440,3 +440,27 @@ function companion_api_request( string $endpoint ) {
 		]
 	);
 }
+
+/**
+ * Get an option that should be set on the main site for multisite installs.
+ *
+ * @param string $option The option name.
+ * @param mixed $default (Optional) The default value to return if the option is not set.
+ *
+ * @return mixed
+ */
+function companion_get_multisite_option( string $option, $default = null ) {
+	return is_multisite() ? get_blog_option( 1, $option, $default ) : get_option( $option, $default );
+}
+
+/**
+ * Update an option that should be set on the main site for multisite installs.
+ *
+ * @param string $option The option name.
+ * @param mixed $value The option value.
+ *
+ * @return bool
+ */
+function companion_update_multisite_option( string $option, $value ) {
+	return is_multisite() ? update_blog_option( 1, $option, $value ) : update_option( $option, $value );
+}

--- a/companion.php
+++ b/companion.php
@@ -33,10 +33,10 @@ add_action( 'pre_current_active_plugins', 'companion_hide_plugin' );
 companion_tamper_with_jetpack_constants();
 add_action( 'init', 'companion_add_jetpack_constants_option_page' );
 
-function clipboard( $target, $inner = '&#x1f4cb;' ) {
-?>
-	<a class="jurassic_ninja_field_clipboard" target="<?php echo $target; ?>" href="#"><?php echo $inner; ?></a>
-<?php
+function companion_clipboard( $target, $inner = '&#x1f4cb;' ) {
+	?>
+	<a class="jurassic_ninja_field_clipboard" target="<?php echo esc_attr( $target ); ?>" href="#"><?php echo $inner; ?></a>
+	<?php
 }
 
 function companion_admin_notices() {
@@ -65,29 +65,29 @@ function companion_admin_notices() {
 		</h3>
 		<p>
 			<strong><span id="jurassic_url" class="jurassic_ninja_field"><?php echo esc_html( network_site_url() ); ?></span></strong>
-			<?php clipboard( 'jurassic_url' ); ?>
 			<?php echo esc_html__( 'will be destroyed in 7 days.' ); ?>
+			<?php companion_clipboard( 'jurassic_url' ); ?>
 		</p>
 		<p>
 			<strong>User:</strong> <code id="jurassic_username" class="jurassic_ninja_field">demo</code> 
 			<code id="jurassic_password" class="jurassic_ninja_field"><?php echo esc_html( $admin_password ); ?></code>
-			<?php clipboard( 'jurassic_password' ); ?>
+			<?php companion_clipboard( 'jurassic_password' ); ?>
 		</p>
 		<p>
 			<strong>SSH User:</strong> <code id="jurassic_ssh_user" class="jurassic_ninja_field"><?php echo esc_html( $sysuser ); ?></code>
-			<?php clipboard( 'jurassic_ssh_user' ); ?>
 			<strong>Password:</strong> <code id="jurassic_ssh_password" class="jurassic_ninja_field"><?php echo esc_html( $ssh_password ); ?></code>
-			<?php clipboard( 'jurassic_ssh_password' ); ?>
+			<?php companion_clipboard( 'jurassic_ssh_user' ); ?>
+			<?php companion_clipboard( 'jurassic_ssh_password' ); ?>
 			<span style="display:none" id="jurassic_ssh"><?php echo esc_html( $ssh ); ?></span>
 			<span style="display:none" id="jurassic_sftp"><?php echo esc_html( $sftp ); ?></span>
 			<strong>SSH command</strong>
-			<?php clipboard( 'jurassic_ssh' ); ?>
+			<?php companion_clipboard( 'jurassic_ssh' ); ?>
 			<strong>SFTP connection string</strong>
-			<?php clipboard( 'jurassic_sftp' ); ?>
+			<?php companion_clipboard( 'jurassic_sftp' ); ?>
 		</p>
 		<p>
 			<strong>Server path:</strong> <code id="jurassic_ninja_server_path" class="jurassic_ninja_field"><?php echo esc_html( get_home_path() ); ?></code>
-			<?php clipboard( 'jurassic_ninja_server_path' ); ?>
+			<?php companion_clipboard( 'jurassic_ninja_server_path' ); ?>
 		</p>
 	</div>
 	<style type="text/css">

--- a/companion.php
+++ b/companion.php
@@ -48,6 +48,25 @@ function companion_clipboard( $target, $inner = '&#x1f4cb;' ) {
 	<?php
 }
 
+/**
+ * Get the number of days remaining before this site is destroyed.
+ *
+ * @return int
+ */
+function companion_get_days_remaining() {
+	$last_checkin = (int) companion_get_multisite_option( 'jurassic_ninja_last_checkin', 0 );
+	if ( 0 === $last_checkin ) {
+		return 0;
+	}
+
+	$last_date = new DateTimeImmutable( "@{$last_checkin}" );
+	$now = new DateTimeImmutable();
+
+	$diff = date_diff( $now, $last_date );
+
+	return 7 - $diff->d;
+}
+
 function companion_admin_notices() {
 	if ( ! companion_get_option( 'jurassic_ninja_credentials_notice', true ) ) {
 		return;

--- a/companion.php
+++ b/companion.php
@@ -33,6 +33,15 @@ add_action( 'pre_current_active_plugins', 'companion_hide_plugin' );
 companion_tamper_with_jetpack_constants();
 add_action( 'init', 'companion_add_jetpack_constants_option_page' );
 
+/**
+ * Get the API base URL for Jurassic Ninja.
+ *
+ * @return string
+ */
+function companion_get_api_base_url() {
+	return (string) get_option( 'companion_api_base_url', 'https://jurassic.ninja/wp-json/jurassic.ninja' );
+}
+
 function companion_clipboard( $target, $inner = '&#x1f4cb;' ) {
 	?>
 	<a class="jurassic_ninja_field_clipboard" target="<?php echo esc_attr( $target ); ?>" href="#"><?php echo $inner; ?></a>

--- a/companion.php
+++ b/companion.php
@@ -181,12 +181,10 @@ function companion_admin_notices() {
 
 function companion_hide_plugin() {
 	global $wp_list_table;
-	$hidearr = array( 'companion/companion.php' );
-	$myplugins = $wp_list_table->items;
-	foreach ( $myplugins as $key => $val ) {
-		if ( in_array( $key, $hidearr, true ) ) {
-			unset( $wp_list_table->items[ $key ] );
-		}
+
+	$plugin_file = plugin_basename( __FILE__ );
+	if ( array_key_exists( $plugin_file, $wp_list_table->items ) ) {
+		unset( $wp_list_table->items[ $plugin_file ] );
 	}
 }
 


### PR DESCRIPTION
Curretnly, the Admin notice for the companion plugin says that the site will be destroyed in 7 days. This value never changes based on when the site was last checked in.

This PR adds a method to determine how many days *really* remain, to make it more apparent when the site will be deleted.

For reviewing this PR, I recommend looking at each commit in order, as it might make it easier to see how the changes came together. I did a little bit of other cleanup along the way that might be a bit confusing when looking at the changes as a whole.

