### PR TITLE
Access password from persistent data on Atomic

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -259,6 +259,10 @@ function companion_after_setup_theme() {
 
 	if ( $do_login ) {
 		$password               = get_option( 'jurassic_ninja_admin_password' );
+		if ( defined( 'IS_ATOMIC_JN' ) && IS_ATOMIC_JN ) {
+			$persistent_data = new Atomic_Persistent_Data();
+			$password        = $persistent_data->JN_PASSWORD;
+		}
 		$creds                  = array();
 		$creds['user_login']    = 'demo';
 		$creds['user_password'] = $password;


### PR DESCRIPTION
Atomic supports persistent data that encrypts information. It is readily accessible on the atomic site via the Atomic_Persistent_Data class. This updates companion to reference the persistent data to load the password so it won't be visible in WP options.