### PR TITLE
Jurassic.Ninja : Restrict emails to send to site owner

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -50,7 +50,7 @@ if ( defined( 'IS_ATOMIC_JN' ) && IS_ATOMIC_JN ) {
  * @return mixed
  */
 function companion_user_has_cap( $all, $caps ) {
-    if ( $all['install_plugins'] == 1 ) {
+    if ( isset( $all['install_plugins' ] ) && $all['install_plugins'] == 1 ) {
 	    $all['update_core'] = 1;
     }
 	return $all;

--- a/companion.php
+++ b/companion.php
@@ -60,7 +60,7 @@ function companion_user_has_cap( $all, $caps ) {
  * Disallowed Plugins from being installed on Jurassic.Ninja sites.
  */
 $companion_disallowed_plugins_list = [
-    'wordpress-seo',
+    // plugin slugs
 ];
 
 /**
@@ -74,22 +74,23 @@ $companion_disallowed_plugins_list = [
  * @return mixed
  */
 function companion_prevent_disallowed_plugin_from_installing_and_activation( $all_caps, $caps, $args, $extra ) {
-	// Plugin Install Flow.
+	global $companion_disallowed_plugins_list;
+    // Plugin Install Flow.
     if ( isset( $_POST['slug'] ) ) {
 		$slug  = sanitize_key( wp_unslash( $_POST['slug'] ) );
 
-		if ( isset( $companion_disallowed_plugins_list[ $slug ] ) ) {
-			unset($all_caps['install_plugins']);
-			unset($all_caps['activate_plugins']);
-			unset($all_caps['update_plugins']);
-		}
+	    if ( in_array( $slug, $companion_disallowed_plugins_list ) ) {
+		    unset($all_caps['install_plugins']);
+		    unset($all_caps['activate_plugins']);
+		    unset($all_caps['update_plugins']);
+	    }
 	}
-
+	https://really-steady.jurassic.ninja/wp-admin/plugins.php?action=activate&plugin=wordpress-seo%2Fwp-seo.php&plugin_status=all&paged=1&s&_wpnonce=d184a68021
     // Plugin activation.
 	if ( isset( $_GET['plugin'] ) && isset( $_GET['action'] ) && $_GET['action'] == 'activate' ) {
 		$slug = explode('/', $_GET['plugin'])[0];
 
-		if ( isset( $companion_disallowed_plugins_list[ $slug ] ) ) {
+		if ( in_array( $slug, $companion_disallowed_plugins_list ) ) {
 			unset($all_caps['install_plugins']);
 			unset($all_caps['activate_plugins']);
 			unset($all_caps['update_plugins']);


### PR DESCRIPTION
Add various hardening logic for sites running on WP.cloud

1) Restrict emails so they are sent to the admin's email
2) Implement block on installing disallowed plugins.
3) update logic on when to allow update_core permission